### PR TITLE
feat: Add custom model configuration and provider settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,8 @@ Stay in control of what the AI can do:
 | `mysti.brainstorm.discussionMode` | `quick` | `quick` or `full` |
 | `mysti.accessLevel` | `ask-permission` | File access level |
 | `mysti.agents.autoSuggest` | `true` | Auto-suggest personas |
+| `mysti.codexProfile` | `""` | OpenAI Codex Profile name (defined in `~/.codex/config.toml`) |
+| `mysti.codexModel` | `""` | Custom OpenAI Codex model (overrides chat UI selection) |
 | `mysti.copilotPath` | `copilot` | Path to GitHub Copilot CLI executable |
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "mysti",
-  "version": "0.1.0",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mysti",
-      "version": "0.1.0",
-      "license": "BUSL-1.1",
+      "version": "0.2.2",
+      "license": "MIT",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.0",
         "marked": "^15.0.0",
@@ -510,6 +510,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -915,6 +916,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1107,6 +1109,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -1379,6 +1382,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2760,6 +2764,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3104,6 +3109,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3193,6 +3199,7 @@
       "integrity": "sha512-HU1JOuV1OavsZ+mfigY0j8d1TgQgbZ6M+J75zDkpEAwYeXjWSqrGJtgnPblJjd/mAyTNQ7ygw0MiKOn6etz8yw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -3242,6 +3249,7 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -199,15 +199,40 @@
           "default": "codex",
           "description": "Path to OpenAI Codex CLI executable"
         },
+        "mysti.codexProfile": {
+          "type": "string",
+          "default": "",
+          "description": "OpenAI Codex Profile name to use (defined in ~/.codex/config.toml). Leave empty to use default profile."
+        },
+        "mysti.codexModel": {
+          "type": "string",
+          "default": "",
+          "description": "Custom OpenAI Codex model to use. Overrides the model selection in chat UI. Leave empty to use the selected model or default."
+        },
         "mysti.geminiPath": {
           "type": "string",
           "default": "gemini",
           "description": "Path to Google Gemini CLI executable"
         },
+        "mysti.geminiModel": {
+          "type": "string",
+          "default": "",
+          "description": "Custom Google Gemini model to use. Overrides the model selection in chat UI. Leave empty to use the selected model or default."
+        },
+        "mysti.claudeCodeModel": {
+          "type": "string",
+          "default": "",
+          "description": "Custom Claude Code model to use. Overrides the model selection in chat UI. Leave empty to use the selected model or default."
+        },
         "mysti.copilotPath": {
           "type": "string",
           "default": "copilot",
           "description": "Path to GitHub Copilot CLI executable"
+        },
+        "mysti.copilotModel": {
+          "type": "string",
+          "default": "",
+          "description": "Custom GitHub Copilot model to use. Overrides the model selection in chat UI. Leave empty to use the selected model or default."
         },
         "mysti.defaultMode": {
           "type": "string",

--- a/src/providers/ChatViewProvider.ts
+++ b/src/providers/ChatViewProvider.ts
@@ -228,6 +228,23 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
       showSuggestions: agentConfig.get<boolean>('showSuggestions', true)
     };
 
+    // Get provider-specific settings
+    let customModel = '';
+    if (selectedProvider === 'openai-codex') {
+      customModel = config.get<string>('codexModel', '');
+    } else if (selectedProvider === 'google-gemini') {
+      customModel = config.get<string>('geminiModel', '');
+    } else if (selectedProvider === 'claude-code') {
+      customModel = config.get<string>('claudeCodeModel', '');
+    } else if (selectedProvider === 'github-copilot') {
+      customModel = config.get<string>('copilotModel', '');
+    }
+
+    const providerSettings = {
+      codexProfile: config.get<string>('codexProfile', ''),
+      customModel: customModel
+    };
+
     // Get brainstorm agent configuration
     const brainstormAgents = vscode.workspace.getConfiguration('mysti')
       .get<string[]>('brainstorm.agents', ['claude-code', 'openai-codex']);
@@ -259,6 +276,7 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
         availablePersonas,
         availableSkills,
         agentSettings,
+        providerSettings,
         brainstormAgents
       }
     });
@@ -1295,6 +1313,29 @@ export class ChatViewProvider implements vscode.WebviewViewProvider {
     }
     if ('showSuggestions' in settingsAny) {
       await config.update('showSuggestions', settingsAny['showSuggestions'], vscode.ConfigurationTarget.Global);
+    }
+
+    // Handle Codex provider settings
+    if ('codexProfile' in settingsAny) {
+      await config.update('codexProfile', settingsAny['codexProfile'], vscode.ConfigurationTarget.Global);
+      console.log(`[Mysti] Updated codexProfile to: ${settingsAny['codexProfile']}`);
+    }
+    if ('customModel' in settingsAny) {
+      // Store custom model in the currently selected provider's config
+      const currentProvider = config.get<ProviderType>('defaultProvider', 'claude-code');
+      if (currentProvider === 'openai-codex') {
+        await config.update('codexModel', settingsAny['customModel'], vscode.ConfigurationTarget.Global);
+        console.log(`[Mysti] Updated codexModel to: ${settingsAny['customModel']}`);
+      } else if (currentProvider === 'google-gemini') {
+        await config.update('geminiModel', settingsAny['customModel'], vscode.ConfigurationTarget.Global);
+        console.log(`[Mysti] Updated geminiModel to: ${settingsAny['customModel']}`);
+      } else if (currentProvider === 'claude-code') {
+        await config.update('claudeCodeModel', settingsAny['customModel'], vscode.ConfigurationTarget.Global);
+        console.log(`[Mysti] Updated claudeCodeModel to: ${settingsAny['customModel']}`);
+      } else if (currentProvider === 'github-copilot') {
+        await config.update('copilotModel', settingsAny['customModel'], vscode.ConfigurationTarget.Global);
+        console.log(`[Mysti] Updated copilotModel to: ${settingsAny['customModel']}`);
+      }
     }
 
     // Handle brainstorm agent selection


### PR DESCRIPTION
## Summary

This PR adds support for custom model configuration and provider-specific settings across all AI providers.

- Add `mysti.codexProfile` setting to specify Codex profile from `~/.codex/config.toml`
- Add `mysti.codexModel` setting for custom OpenAI Codex models
- Add `mysti.geminiModel` setting for custom Google Gemini models
- Add `mysti.claudeCodeModel` setting for custom Claude Code models
- Add `mysti.copilotModel` setting for custom GitHub Copilot models
- Update webview UI with custom model input field (shown when "Custom" model is selected)
- Add Codex-specific settings section in webview for profile configuration
- Update `ChatViewProvider` to handle provider-specific custom model settings
- Update `CodexProvider` to use profile and custom model from VSCode settings
- Change license from BUSL-1.1 to MIT

## Test plan

- [ ] Test custom model configuration for each provider (Codex, Gemini, Claude Code, Copilot)
- [ ] Verify Codex profile setting works correctly
- [ ] Test the webview UI shows/hides custom model input based on selection
- [ ] Test Codex settings section visibility toggles correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)