### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,7 +199,8 @@
             "opencode",
             "ollama",
             "localai",
-            "qwen-code"
+            "qwen-code",
+            "minimax"
           ],
           "enumDescriptions": [
             "Claude Code CLI (Anthropic) - Deep reasoning, complex refactoring, thorough analysis",
@@ -212,7 +213,8 @@
             "OpenCode - Multi-provider AI coding agent with support for OpenAI, Anthropic, Gemini, Groq, and OpenRouter",
             "Ollama - Local LLM inference server supporting Llama, CodeLlama, Mistral, and more",
             "LocalAI - Self-hosted OpenAI-compatible local inference with GPU/CPU support",
-            "Qwen Code - Alibaba's AI coding agent with Qwen3-Coder models and multi-provider support"
+            "Qwen Code - Alibaba's AI coding agent with Qwen3-Coder models and multi-provider support",
+            "MiniMax - MiniMax AI cloud API with MiniMax-M2.7 models and OpenAI-compatible interface"
           ],
           "description": "Primary AI provider for coding assistance. Switch providers anytime without losing context."
         },
@@ -343,6 +345,40 @@
           "default": 120000,
           "minimum": 5000,
           "description": "Request timeout in milliseconds for LocalAI. Increase for large models or slow hardware."
+        },
+        "mysti.minimaxApiKey": {
+          "type": "string",
+          "default": "",
+          "description": "API key for MiniMax. Get your key at https://platform.minimax.io. Can also be set via the MINIMAX_API_KEY environment variable."
+        },
+        "mysti.minimaxBaseUrl": {
+          "type": "string",
+          "default": "https://api.minimax.io/v1",
+          "description": "MiniMax API base URL (OpenAI-compatible endpoint)."
+        },
+        "mysti.minimaxModel": {
+          "type": "string",
+          "default": "",
+          "description": "Model to use with MiniMax. Leave empty to use MiniMax-M2.7 (default). Options: MiniMax-M2.7, MiniMax-M2.7-highspeed."
+        },
+        "mysti.minimaxTemperature": {
+          "type": "number",
+          "default": 1.0,
+          "minimum": 0.01,
+          "maximum": 1.0,
+          "description": "Sampling temperature for MiniMax (0.01-1.0). MiniMax does not accept 0; default is 1.0."
+        },
+        "mysti.minimaxMaxTokens": {
+          "type": "number",
+          "default": 0,
+          "minimum": 0,
+          "description": "Maximum tokens to generate with MiniMax (0 = no limit)."
+        },
+        "mysti.minimaxRequestTimeout": {
+          "type": "number",
+          "default": 120000,
+          "minimum": 5000,
+          "description": "Request timeout in milliseconds for MiniMax."
         },
         "mysti.defaultMode": {
           "type": "string",
@@ -617,7 +653,8 @@
             "opencode",
             "ollama",
             "localai",
-            "qwen-code"
+            "qwen-code",
+            "minimax"
           ],
           "description": "Agent to use for synthesis in brainstorm mode"
         },
@@ -640,13 +677,14 @@
               "opencode",
               "ollama",
               "localai",
-              "qwen-code"
+              "qwen-code",
+              "minimax"
             ]
           },
           "minItems": 2,
           "maxItems": 2,
           "uniqueItems": true,
-          "description": "Select any 2 of 10 AI providers to collaborate in brainstorm mode. Different combinations offer unique strengths."
+          "description": "Select any 2 of 11 AI providers to collaborate in brainstorm mode. Different combinations offer unique strengths."
         },
         "mysti.agents.claudePersona": {
           "type": "string",
@@ -946,6 +984,34 @@
           "type": "string",
           "default": "",
           "description": "Custom persona prompt for Qwen Code (when persona is 'custom')"
+        },
+        "mysti.agents.minimaxPersona": {
+          "type": "string",
+          "default": "neutral",
+          "enum": [
+            "neutral",
+            "architect",
+            "pragmatist",
+            "engineer",
+            "reviewer",
+            "designer",
+            "custom"
+          ],
+          "enumDescriptions": [
+            "Balanced, no specific bias",
+            "Focus on system design and patterns",
+            "Focus on practical, working solutions",
+            "Focus on implementation quality and performance",
+            "Focus on code review and best practices",
+            "Focus on API design and UX",
+            "Use custom prompt"
+          ],
+          "description": "Persona for MiniMax agent in brainstorm mode"
+        },
+        "mysti.agents.minimaxCustomPrompt": {
+          "type": "string",
+          "default": "",
+          "description": "Custom persona prompt for MiniMax (when persona is 'custom')"
         },
         "mysti.agents.autoSuggest": {
           "type": "boolean",

--- a/src/managers/BrainstormManager.ts
+++ b/src/managers/BrainstormManager.ts
@@ -87,6 +87,11 @@ const AGENT_STYLES: Record<AgentType, { color: string; icon: string; displayName
     color: '#6C5CE7', // Purple
     icon: '🟪',
     displayName: 'Qwen'
+  },
+  'minimax': {
+    color: '#FF6B35', // Orange
+    icon: '🟧',
+    displayName: 'MiniMax'
   }
 };
 
@@ -156,7 +161,8 @@ export class BrainstormManager {
       'opencode': 'opencode',
       'ollama': 'ollama',
       'localai': 'localai',
-      'qwen-code': 'qwenCode'
+      'qwen-code': 'qwenCode',
+      'minimax': 'minimax'
     };
     const agentKey = agentKeyMap[agentId] || 'claude';
 

--- a/src/providers/ProviderRegistry.ts
+++ b/src/providers/ProviderRegistry.ts
@@ -24,6 +24,7 @@ import { OpenCodeProvider } from './opencode/OpenCodeProvider';
 import { OllamaProvider } from './ollama/OllamaProvider';
 import { LocalAIProvider } from './localai/LocalAIProvider';
 import { QwenCodeProvider } from './qwen/QwenCodeProvider';
+import { MiniMaxProvider } from './minimax/MiniMaxProvider';
 
 /**
  * Registry for managing CLI providers
@@ -97,6 +98,11 @@ export class ProviderRegistry {
     const qwen = new QwenCodeProvider(this._extensionContext);
     this._providers.set(qwen.id, qwen);
     console.log(`[Mysti] Registered provider: ${qwen.displayName}`);
+
+    // Register MiniMax
+    const minimax = new MiniMaxProvider(this._extensionContext);
+    this._providers.set(minimax.id, minimax);
+    console.log(`[Mysti] Registered provider: ${minimax.displayName}`);
 
   }
 

--- a/src/providers/minimax/MiniMaxProvider.ts
+++ b/src/providers/minimax/MiniMaxProvider.ts
@@ -1,0 +1,342 @@
+/**
+ * Mysti - AI Coding Agent
+ * Copyright (c) 2025 DeepMyst Inc. All rights reserved.
+ *
+ * This file is part of Mysti, licensed under the Apache License, Version 2.0.
+ * See the LICENSE file in the project root for full license terms.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode';
+import { BaseCliProvider, type PanelSessionState } from '../base/BaseCliProvider';
+import type {
+  CliDiscoveryResult,
+  AuthConfig,
+  ProviderCapabilities,
+  PersonaConfig,
+} from '../base/IProvider';
+import type {
+  Settings,
+  StreamChunk,
+  ProviderConfig,
+  AuthStatus,
+  ContextItem,
+  Conversation,
+  AgentConfiguration,
+  Attachment,
+} from '../../types';
+
+/**
+ * Per-panel session state for MiniMax HTTP provider
+ */
+export interface MiniMaxSessionState extends PanelSessionState {
+  abortController: AbortController | null;
+  lastUsageStats: { input_tokens: number; output_tokens: number } | null;
+}
+
+/**
+ * MiniMax provider implementation using OpenAI-compatible HTTP API
+ *
+ * MiniMax exposes an OpenAI-compatible API at /v1/chat/completions with SSE streaming.
+ * API key is configured via the MINIMAX_API_KEY environment variable or the
+ * mysti.minimaxApiKey setting.
+ *
+ * API: POST /v1/chat/completions (OpenAI-compatible)
+ * Docs: https://platform.minimax.io/docs/api-reference/text-openai-api
+ */
+export class MiniMaxProvider extends BaseCliProvider {
+  readonly id = 'minimax';
+  readonly displayName = 'MiniMax';
+
+  readonly config: ProviderConfig = {
+    name: 'minimax',
+    displayName: 'MiniMax',
+    models: [
+      {
+        id: 'MiniMax-M2.7',
+        name: 'MiniMax-M2.7',
+        description: 'Peak Performance. Ultimate Value. Master the Complex.',
+        contextWindow: 1000000,
+      },
+      {
+        id: 'MiniMax-M2.7-highspeed',
+        name: 'MiniMax-M2.7-highspeed',
+        description: 'Same performance, faster and more agile.',
+        contextWindow: 1000000,
+      },
+    ],
+    defaultModel: 'MiniMax-M2.7',
+  };
+
+  readonly capabilities: ProviderCapabilities = {
+    supportsStreaming: true,
+    supportsThinking: false,
+    supportsToolUse: false,
+    supportsSessions: false,
+    supportsImages: false,
+    supportsAutoInstall: false,
+  };
+
+  protected _createSession(panelId: string): MiniMaxSessionState {
+    return {
+      panelId,
+      process: null,
+      sessionId: null,
+      autonomousMode: false,
+      persistentProcess: null,
+      persistentReady: false,
+      lastHealthCheck: 0,
+      suspended: false,
+      abortController: null,
+      lastUsageStats: null,
+    };
+  }
+
+  // --- Configuration helpers ---
+
+  private _getBaseUrl(): string {
+    return vscode.workspace.getConfiguration('mysti').get<string>(
+      'minimaxBaseUrl',
+      'https://api.minimax.io/v1',
+    );
+  }
+
+  private _getApiKey(): string {
+    return (
+      vscode.workspace.getConfiguration('mysti').get<string>('minimaxApiKey', '') ||
+      process.env.MINIMAX_API_KEY ||
+      ''
+    );
+  }
+
+  // --- Discovery (API key presence check) ---
+
+  async discoverCli(): Promise<CliDiscoveryResult> {
+    const apiKey = this._getApiKey();
+    if (apiKey) {
+      return { found: true, path: this._getBaseUrl() };
+    }
+    return {
+      found: false,
+      path: this._getBaseUrl(),
+      installCommand: this.getInstallCommand(),
+    };
+  }
+
+  getCliPath(): string {
+    return this._getBaseUrl();
+  }
+
+  // --- Authentication ---
+
+  async getAuthConfig(): Promise<AuthConfig> {
+    return {
+      type: 'api-key',
+      isAuthenticated: !!this._getApiKey(),
+    };
+  }
+
+  async checkAuthentication(): Promise<AuthStatus> {
+    const apiKey = this._getApiKey();
+    if (!apiKey) {
+      return {
+        authenticated: false,
+        error: 'MiniMax API key not set. Configure mysti.minimaxApiKey or set the MINIMAX_API_KEY environment variable.',
+      };
+    }
+    return { authenticated: true, user: 'MiniMax API' };
+  }
+
+  getAuthCommand(): string {
+    return 'Set MINIMAX_API_KEY environment variable or configure mysti.minimaxApiKey setting';
+  }
+
+  getInstallCommand(): string {
+    return 'Get your API key at https://platform.minimax.io and set mysti.minimaxApiKey';
+  }
+
+  // --- Stub methods (not used for HTTP provider) ---
+
+  protected buildCliArgs(_settings: Settings, _session: PanelSessionState): string[] {
+    return [];
+  }
+
+  protected parseStreamLine(_line: string, _session: PanelSessionState): StreamChunk | null {
+    return null;
+  }
+
+  protected getThinkingTokens(_thinkingLevel: string): number | undefined {
+    return undefined;
+  }
+
+  // --- Message Sending (OpenAI-compatible HTTP API with SSE streaming) ---
+
+  async *sendMessage(
+    content: string,
+    context: ContextItem[],
+    settings: Settings,
+    conversation: Conversation | null,
+    persona?: PersonaConfig,
+    panelId?: string,
+    _providerManager?: unknown,
+    agentConfig?: AgentConfiguration,
+    attachments?: Attachment[],
+  ): AsyncGenerator<StreamChunk> {
+    const session = this._getSession(panelId) as MiniMaxSessionState;
+    const config = vscode.workspace.getConfiguration('mysti');
+
+    const baseUrl = this._getBaseUrl();
+    const apiKey = this._getApiKey();
+    const model = config.get<string>('minimaxModel', '') || this.config.defaultModel;
+    // MiniMax temperature range is (0.0, 1.0] — default 1.0, must not be 0
+    const temperature = Math.max(0.01, Math.min(1.0, config.get<number>('minimaxTemperature', 1.0)));
+    const maxTokens = config.get<number>('minimaxMaxTokens', 0);
+    const timeout = config.get<number>('minimaxRequestTimeout', 120000);
+
+    if (!apiKey) {
+      yield { type: 'error', content: 'MiniMax API key not configured. Set mysti.minimaxApiKey or MINIMAX_API_KEY.' };
+      yield { type: 'done' };
+      return;
+    }
+
+    session.abortController = new AbortController();
+    const timeoutId = setTimeout(() => session.abortController?.abort(), timeout);
+
+    try {
+      const fullPrompt = await this.buildPromptAsync(
+        content, context, conversation, settings, persona, agentConfig, attachments,
+      );
+
+      const body: Record<string, unknown> = {
+        model,
+        messages: [{ role: 'user', content: fullPrompt }],
+        stream: true,
+        temperature,
+      };
+      if (maxTokens > 0) {
+        body.max_tokens = maxTokens;
+      }
+
+      console.log(`[Mysti] MiniMax: Sending request to ${baseUrl}/chat/completions with model ${model}`);
+
+      const response = await fetch(`${baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify(body),
+        signal: session.abortController.signal,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => '');
+        yield { type: 'error', content: `MiniMax error (${response.status}): ${errorText || response.statusText}` };
+        yield { type: 'done' };
+        return;
+      }
+
+      if (!response.body) {
+        yield { type: 'error', content: 'MiniMax returned no response body' };
+        yield { type: 'done' };
+        return;
+      }
+
+      // Parse SSE stream (OpenAI format: "data: {...}\n\n")
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let totalOutputTokens = 0;
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) { break; }
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop()!;
+
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed || !trimmed.startsWith('data: ')) { continue; }
+
+          const data = trimmed.slice(6);
+          if (data === '[DONE]') { continue; }
+
+          try {
+            const chunk = JSON.parse(data);
+            const choice = chunk.choices?.[0];
+            if (!choice) { continue; }
+
+            const delta = choice.delta;
+
+            if (delta?.content) {
+              totalOutputTokens++;
+              yield { type: 'text', content: delta.content };
+            }
+
+            if (chunk.usage) {
+              session.lastUsageStats = {
+                input_tokens: chunk.usage.prompt_tokens || 0,
+                output_tokens: chunk.usage.completion_tokens || 0,
+              };
+            }
+          } catch {
+            console.log('[Mysti] MiniMax: Failed to parse SSE data:', data.substring(0, 200));
+          }
+        }
+      }
+
+      const usage = session.lastUsageStats || { input_tokens: 0, output_tokens: totalOutputTokens };
+      session.lastUsageStats = null;
+      yield { type: 'done', usage };
+
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        yield { type: 'error', content: 'Request cancelled or timed out' };
+      } else {
+        yield this.handleError(error);
+      }
+      yield { type: 'done' };
+    } finally {
+      clearTimeout(timeoutId);
+      session.abortController = null;
+    }
+  }
+
+  // --- Cancellation ---
+
+  cancelCurrentRequest(panelId?: string): void {
+    if (panelId) {
+      const session = this._panelSessions.get(panelId) as MiniMaxSessionState | undefined;
+      if (session?.abortController) {
+        console.log('[Mysti] MiniMax: Cancelling request for panel:', panelId);
+        session.abortController.abort();
+        session.abortController = null;
+      }
+    }
+    super.cancelCurrentRequest(panelId);
+  }
+
+  getStoredUsage(panelId?: string): { input_tokens: number; output_tokens: number } | null {
+    const session = this._getSession(panelId) as MiniMaxSessionState;
+    const usage = session.lastUsageStats;
+    session.lastUsageStats = null;
+    return usage;
+  }
+
+  clearSession(panelId?: string): void {
+    super.clearSession(panelId);
+    if (panelId) {
+      const session = this._panelSessions.get(panelId) as MiniMaxSessionState | undefined;
+      if (session) {
+        session.lastUsageStats = null;
+        if (session.abortController) {
+          session.abortController.abort();
+          session.abortController = null;
+        }
+      }
+    }
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,11 +15,11 @@ export type OperationMode = 'default' | 'ask-before-edit' | 'edit-automatically'
 export type ThinkingLevel = 'none' | 'low' | 'medium' | 'high';
 export type AccessLevel = 'read-only' | 'ask-permission' | 'full-access';
 export type ContextMode = 'auto' | 'manual';
-export type ProviderType = 'claude-code' | 'openai-codex' | 'google-gemini' | 'cline' | 'github-copilot' | 'cursor' | 'openclaw' | 'opencode' | 'ollama' | 'localai' | 'qwen-code';
+export type ProviderType = 'claude-code' | 'openai-codex' | 'google-gemini' | 'cline' | 'github-copilot' | 'cursor' | 'openclaw' | 'opencode' | 'ollama' | 'localai' | 'qwen-code' | 'minimax';
 export type AutocompleteType = 'sentence' | 'paragraph' | 'message';
 
 // Agent and Brainstorm types
-export type AgentType = 'claude-code' | 'openai-codex' | 'google-gemini' | 'cline' | 'github-copilot' | 'cursor' | 'openclaw' | 'opencode' | 'ollama' | 'localai' | 'qwen-code';
+export type AgentType = 'claude-code' | 'openai-codex' | 'google-gemini' | 'cline' | 'github-copilot' | 'cursor' | 'openclaw' | 'opencode' | 'ollama' | 'localai' | 'qwen-code' | 'minimax';
 export type PersonaType = 'neutral' | 'architect' | 'pragmatist' | 'engineer' | 'reviewer' | 'designer' | 'custom';
 export type BrainstormPhase = 'initial' | 'individual' | 'discussion' | 'synthesis' | 'complete';
 export type CollaborationStrategy = 'quick' | 'debate' | 'red-team' | 'perspectives' | 'delphi';

--- a/tests/helpers/providerFactory.ts
+++ b/tests/helpers/providerFactory.ts
@@ -14,6 +14,7 @@ import { CursorProvider } from '../../src/providers/cursor/CursorProvider';
 import { OpenClawProvider } from '../../src/providers/openclaw/OpenClawProvider';
 import { OpenCodeProvider } from '../../src/providers/opencode/OpenCodeProvider';
 import { QwenCodeProvider } from '../../src/providers/qwen/QwenCodeProvider';
+import { MiniMaxProvider } from '../../src/providers/minimax/MiniMaxProvider';
 
 // Mock extension context for provider constructors
 function createMockContext(): vscode.ExtensionContext {
@@ -138,4 +139,8 @@ export class TestableQwenProvider extends QwenCodeProvider {
   public buildCliArgs(settings: Settings, session: PanelSessionState): string[] {
     return super.buildCliArgs(settings, session);
   }
+}
+
+export class TestableMiniMaxProvider extends MiniMaxProvider {
+  constructor() { super(createMockContext()); }
 }

--- a/tests/helpers/sessionFactory.ts
+++ b/tests/helpers/sessionFactory.ts
@@ -4,6 +4,7 @@
 import type { PanelSessionState } from '../../src/providers/base/BaseCliProvider';
 import type { ClaudeSessionState } from '../../src/providers/claude/ClaudeCodeProvider';
 import type { QwenSessionState } from '../../src/providers/qwen/QwenCodeProvider';
+import type { MiniMaxSessionState } from '../../src/providers/minimax/MiniMaxProvider';
 
 // Re-export session state types for provider-specific fields
 // Some providers don't export their session type, so we define compatible objects inline.
@@ -101,6 +102,14 @@ export function createOpenCodeSession(panelId = 'test-panel') {
     ...baseSession(panelId),
     activeToolCalls: new Map<string, { id: string; name: string; input: Record<string, unknown> }>(),
     completedToolCalls: new Set<string>(),
+    lastUsageStats: null,
+  };
+}
+
+export function createMiniMaxSession(panelId = 'test-panel'): MiniMaxSessionState {
+  return {
+    ...baseSession(panelId),
+    abortController: null,
     lastUsageStats: null,
   };
 }

--- a/tests/providers/minimax/provider.test.ts
+++ b/tests/providers/minimax/provider.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TestableMiniMaxProvider } from '../../helpers/providerFactory';
+import { setMockConfig, clearMockConfig } from '../../helpers/mockVscode';
+
+describe('MiniMaxProvider', () => {
+  let provider: TestableMiniMaxProvider;
+
+  beforeEach(() => {
+    clearMockConfig();
+    provider = new TestableMiniMaxProvider();
+  });
+
+  describe('metadata', () => {
+    it('has the correct id', () => {
+      expect(provider.id).toBe('minimax');
+    });
+
+    it('has the correct displayName', () => {
+      expect(provider.displayName).toBe('MiniMax');
+    });
+
+    it('has MiniMax-M2.7 as the default model', () => {
+      expect(provider.config.defaultModel).toBe('MiniMax-M2.7');
+    });
+
+    it('includes MiniMax-M2.7 and MiniMax-M2.7-highspeed models', () => {
+      const modelIds = provider.config.models.map(m => m.id);
+      expect(modelIds).toContain('MiniMax-M2.7');
+      expect(modelIds).toContain('MiniMax-M2.7-highspeed');
+      expect(modelIds).toHaveLength(2);
+    });
+
+    it('does not support tool use', () => {
+      expect(provider.capabilities.supportsToolUse).toBe(false);
+    });
+
+    it('supports streaming', () => {
+      expect(provider.capabilities.supportsStreaming).toBe(true);
+    });
+  });
+
+  describe('discoverCli', () => {
+    it('returns found=true when API key is configured', async () => {
+      setMockConfig('minimaxApiKey', 'test-api-key');
+      const result = await provider.discoverCli();
+      expect(result.found).toBe(true);
+    });
+
+    it('returns found=false when no API key is set', async () => {
+      // Ensure no env var either
+      const originalEnv = process.env.MINIMAX_API_KEY;
+      delete process.env.MINIMAX_API_KEY;
+      const result = await provider.discoverCli();
+      expect(result.found).toBe(false);
+      if (originalEnv !== undefined) {
+        process.env.MINIMAX_API_KEY = originalEnv;
+      }
+    });
+
+    it('uses the configured base URL in discovery result', async () => {
+      setMockConfig('minimaxApiKey', 'test-key');
+      setMockConfig('minimaxBaseUrl', 'https://api.minimax.io/v1');
+      const result = await provider.discoverCli();
+      expect(result.path).toContain('minimax.io');
+    });
+  });
+
+  describe('checkAuthentication', () => {
+    it('returns authenticated=true when API key is set', async () => {
+      setMockConfig('minimaxApiKey', 'test-api-key');
+      const result = await provider.checkAuthentication();
+      expect(result.authenticated).toBe(true);
+    });
+
+    it('returns authenticated=false when no API key is set', async () => {
+      const originalEnv = process.env.MINIMAX_API_KEY;
+      delete process.env.MINIMAX_API_KEY;
+      const result = await provider.checkAuthentication();
+      expect(result.authenticated).toBe(false);
+      expect(result.error).toBeDefined();
+      if (originalEnv !== undefined) {
+        process.env.MINIMAX_API_KEY = originalEnv;
+      }
+    });
+  });
+
+  describe('getCliPath', () => {
+    it('returns the default MiniMax base URL', () => {
+      const path = provider.getCliPath();
+      expect(path).toContain('minimax.io');
+    });
+
+    it('returns the configured base URL when overridden', () => {
+      setMockConfig('minimaxBaseUrl', 'https://custom.endpoint/v1');
+      // Create a fresh provider to pick up config
+      const p = new TestableMiniMaxProvider();
+      expect(p.getCliPath()).toBe('https://custom.endpoint/v1');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `MiniMaxProvider` using the OpenAI-compatible HTTP API (`https://api.minimax.io/v1`) — same pattern as the existing `LocalAIProvider`
- Supports **MiniMax-M2.7** (default) and **MiniMax-M2.7-highspeed** models with SSE streaming
- API key configured via `mysti.minimaxApiKey` setting or `MINIMAX_API_KEY` environment variable
- Register provider in `ProviderRegistry`, add to `ProviderType`/`AgentType` union types, and add `AGENT_STYLES` entry in `BrainstormManager` so MiniMax can participate in brainstorm mode
- Add 6 new `package.json` settings: `minimaxApiKey`, `minimaxBaseUrl`, `minimaxModel`, `minimaxTemperature`, `minimaxMaxTokens`, `minimaxRequestTimeout`
- Add 13 unit tests (all passing); full test suite (373 tests) and production build verified

## API Reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api

## Notes

- MiniMax temperature range is `(0.0, 1.0]` — the setting enforces a minimum of `0.01` and maximum of `1.0`
- No Embedding support (MiniMax has no embedding models)
- No TTS support added (Mysti does not have a TTS provider architecture)