### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/resources/agents/core/skills/mmx-cli.md
+++ b/resources/agents/core/skills/mmx-cli.md
@@ -1,0 +1,45 @@
+---
+id: mmx-cli
+name: mmx-cli (MiniMax AI)
+description: Generate text, images, video, speech, and music via MiniMax AI platform
+icon: lab.png
+category: ai-tools
+activationTriggers:
+  - image generation
+  - video generation
+  - speech synthesis
+  - music generation
+  - text generation
+  - minimax
+  - mmx
+  - generate image
+  - generate video
+  - generate audio
+---
+
+# Instructions
+
+Use `mmx` CLI to generate media content via MiniMax AI. Install with `npm install -g @minimax-ai/cli`, then run `mmx auth` to configure your API key.
+
+## Capabilities
+
+- **Text**: `mmx text generate "prompt"` — uses MiniMax-M2.7 model
+- **Image**: `mmx image generate "prompt"` — uses image-01 model
+- **Video**: `mmx video generate "prompt"` — uses Hailuo-2.3 model
+- **Speech**: `mmx speech generate "text"` — uses speech-2.8-hd, 300+ voices
+- **Music**: `mmx music generate "prompt"` — uses music-2.6 with lyrics and cover
+- **Search**: `mmx search "query"` — web search via MiniMax
+
+## Agent Flags
+
+When invoked by an agent, prefer non-interactive mode:
+
+```bash
+mmx image generate "a sunset over mountains" --non-interactive --output json
+mmx speech generate "Hello world" --voice friendly-person --quiet
+mmx music generate "upbeat jazz instrumental" --non-interactive
+```
+
+## Skill Reference
+
+Source: [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli) — `skill/SKILL.md`


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` to `resources/agents/core/skills/` so the mmx-cli skill is discoverable out of the box via Mysti's three-tier agent loading system
- Users can activate the skill by selecting it from the Skills panel — the skill description instructs agents to use the `mmx` CLI for media generation
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md at [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md), no changes needed in this project

**1 file added, 0 existing files modified.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard and includes agent-specific flags (`--non-interactive`, `--quiet`, `--output json`).

## Test plan

- New `mmx-cli` skill appears in the Skills section of the Mysti sidebar
- Activation triggers (`image generation`, `video`, `speech`, `minimax`, etc.) surface the skill in autocomplete suggestions
- Existing skills and personas are unaffected (no existing files modified)