### PR TITLE
Fix channel-scoped OpenClaw contact tracking

### DIFF
--- a/src/managers/ChannelBridge.ts
+++ b/src/managers/ChannelBridge.ts
@@ -70,7 +70,10 @@ export interface QueuedChannelMessage {
 interface TrackedContact {
   /** Normalized identifier (lowercase name or E.164 phone) */
   identifier: string;
-  channel: string;
+  /** Exact OpenClaw channel id when available */
+  channelId: string;
+  /** Channel type used as a fallback when session polling lacks a concrete id */
+  channelType: string;
   /** When the outbound message was sent */
   sentAt: number;
 }
@@ -356,7 +359,7 @@ RULES:
       const prompt = `Send the following message to ${action.to} on ${action.channel}:\n\n${action.content}`;
       const ok = await this._activeModeManager.sendAgentTask(prompt, action.channel);
       console.log(`[Mysti] ChannelBridge: Delegated send to '${action.to}' via agent: ${ok ? 'accepted' : 'failed'}`);
-      if (ok && action.to) { this._trackContact(action.to, action.channel); }
+      if (ok && action.to) { this._trackContact(action.to, channelId, this._resolveChannelType(channelId, action.channel)); }
       return ok;
     }
 
@@ -364,7 +367,7 @@ RULES:
     const target = action.to || this._resolveChannelTarget(action.channel);
     const ok = await this._activeModeManager.sendToChannel(channelId, action.content, target || undefined);
     console.log(`[Mysti] ChannelBridge: Sent to ${action.channel} (${channelId}${target ? ', to: ' + target : ''}): ${ok ? 'success' : 'failed'}`);
-    if (ok && action.to) { this._trackContact(action.to, action.channel); }
+    if (ok && action.to) { this._trackContact(action.to, channelId, this._resolveChannelType(channelId, action.channel)); }
     return ok;
   }
 
@@ -402,7 +405,7 @@ RULES:
     }
 
     // Track the contact so inbound replies are routed
-    if (ok && action.to) { this._trackContact(action.to, action.channel); }
+    if (ok && action.to) { this._trackContact(action.to, channelId, this._resolveChannelType(channelId, action.channel)); }
 
     // Register PendingAsk for both paths so inbound replies can be matched
     if (ok && action.askId) {
@@ -573,7 +576,7 @@ RULES:
               const parsed = this._parseSessionEntry(entry, channelType);
               if (parsed && !this._isDuplicate(parsed)) {
                 // Only route messages from contacts we've actively messaged
-                if (!this._isTrackedConversation(parsed.sender, parsed.channelType)) {
+                if (!this._isTrackedConversation(parsed.sender, parsed.channelId, parsed.channelType)) {
                   continue;
                 }
                 console.log(`[Mysti] ChannelBridge: Inbound poll detected message from ${parsed.sender || 'unknown'} on ${channelType}`);
@@ -685,7 +688,7 @@ RULES:
     }
 
     // Only process messages from contacts we've actively messaged
-    if (!this._isTrackedConversation(event.sender, event.channelType)) {
+    if (!this._isTrackedConversation(event.sender, event.channelId, event.channelType)) {
       return;
     }
 
@@ -760,10 +763,8 @@ RULES:
 
   private _tryMatchPendingAsk(channelId: string, channelType: string, content: string, sender?: string): PendingAsk | null {
     // Search all panels for a matching pending ask
-    for (const [_panelId, asks] of this._pendingAsks) {
-      const channelAsks = asks.filter(a =>
-        !a.reply && (a.channelId === channelId || a.channel === channelType)
-      );
+    for (const asks of this._pendingAsks.values()) {
+      const channelAsks = asks.filter(a => !a.reply && this._matchesInboundChannel(a, channelId, channelType));
       if (channelAsks.length === 0) { continue; }
 
       // Prefer sender-aware matching when both sender and ask.to are available
@@ -791,16 +792,26 @@ RULES:
   }
 
   private _resolveChannelId(channelTypeOrId: string): string | null {
+    const channel = this._resolveChannel(channelTypeOrId);
+    return channel?.id || null;
+  }
+
+  private _resolveChannel(channelTypeOrId: string): ChannelInfo | null {
     const channels = this._activeModeManager.getChannels();
     console.log(`[Mysti] ChannelBridge: Resolving '${channelTypeOrId}' against ${channels.length} channels:`,
       channels.map(c => `${c.id}(type=${c.type},status=${c.status})`).join(', '));
 
     // Try exact ID match first
     const byId = channels.find(c => c.id === channelTypeOrId && c.status === 'connected');
-    if (byId) { return byId.id; }
+    if (byId) { return byId; }
     // Try by type
     const byType = channels.find(c => c.type === channelTypeOrId && c.status === 'connected');
-    return byType?.id || null;
+    return byType || null;
+  }
+
+  private _resolveChannelType(channelId: string, fallback: string): string {
+    const channel = this._activeModeManager.getChannels().find(c => c.id === channelId);
+    return channel?.type || fallback;
   }
 
   private _getProcessedPositions(panelId: string): Set<number> {
@@ -862,14 +873,19 @@ RULES:
    * Register a contact that Mysti has sent a message to.
    * Only messages from tracked contacts will be routed inbound.
    */
-  private _trackContact(nameOrPhone: string, channel: string): void {
-    const key = this._normalizeContactId(nameOrPhone);
-    this._trackedContacts.set(key, {
-      identifier: key,
-      channel,
+  private _trackContact(nameOrPhone: string, channelId: string, channelType: string): void {
+    const identifier = this._normalizeContactId(nameOrPhone);
+    const tracked: TrackedContact = {
+      identifier,
+      channelId,
+      channelType,
       sentAt: Date.now(),
-    });
-    console.log(`[Mysti] ChannelBridge: Tracking contact '${key}' on ${channel} for inbound replies`);
+    };
+
+    for (const scope of this._trackingScopesForOutbound(channelId, channelType)) {
+      this._trackedContacts.set(this._trackedContactKey(scope, identifier), tracked);
+    }
+    console.log(`[Mysti] ChannelBridge: Tracking contact '${identifier}' on ${channelType} (${channelId}) for inbound replies`);
   }
 
   /**
@@ -877,11 +893,12 @@ RULES:
    * Returns false for unknown senders — prevents random conversations
    * from being routed into the AI agent.
    */
-  private _isTrackedConversation(sender: string | undefined, _channelType: string): boolean {
+  private _isTrackedConversation(sender: string | undefined, channelId: string | undefined, channelType: string): boolean {
     if (!sender) { return false; }
 
     const now = Date.now();
     const senderNorm = this._normalizeContactId(sender);
+    const scopes = this._trackingScopesForInbound(channelId, channelType);
 
     for (const [key, contact] of this._trackedContacts) {
       // Expire stale tracked contacts
@@ -891,14 +908,52 @@ RULES:
       }
 
       // Match by normalized identifier (case-insensitive, partial name match)
-      if (key === senderNorm) { return true; }
+      if (!scopes.includes(this._trackedContactScope(key))) { continue; }
+      if (contact.identifier === senderNorm) { return true; }
       // Fuzzy: tracked "Sharif" matches sender "+962792552872" if we also
       // track by phone. And tracked "+962..." matches conversation_label "+962..."
       // Also support partial: tracked "sharif" matches sender "Sharif Abu Nada"
-      if (senderNorm.includes(key) || key.includes(senderNorm)) { return true; }
+      if (senderNorm.includes(contact.identifier) || contact.identifier.includes(senderNorm)) { return true; }
     }
 
     return false;
+  }
+
+  private _matchesInboundChannel(ask: PendingAsk, channelId: string, channelType: string): boolean {
+    if (this._hasSpecificChannelId(channelId, channelType)) {
+      return ask.channelId === channelId;
+    }
+    return ask.channelId === channelId || ask.channel === channelType;
+  }
+
+  private _trackingScopesForOutbound(channelId: string, channelType: string): string[] {
+    const scopes: string[] = [];
+    if (this._hasSpecificChannelId(channelId, channelType)) {
+      scopes.push(`id:${channelId}`);
+    }
+    if (channelType) {
+      scopes.push(`type:${channelType}`);
+    }
+    return [...new Set(scopes)];
+  }
+
+  private _trackingScopesForInbound(channelId: string | undefined, channelType: string): string[] {
+    if (channelId && this._hasSpecificChannelId(channelId, channelType)) {
+      return [`id:${channelId}`];
+    }
+    return channelType ? [`type:${channelType}`] : [];
+  }
+
+  private _hasSpecificChannelId(channelId: string | undefined, channelType: string | undefined): channelId is string {
+    return Boolean(channelId && channelId !== channelType);
+  }
+
+  private _trackedContactKey(scope: string, identifier: string): string {
+    return `${scope}|${identifier}`;
+  }
+
+  private _trackedContactScope(key: string): string {
+    return key.split('|', 1)[0];
   }
 
   /**

--- a/tests/managers/channelBridge.test.ts
+++ b/tests/managers/channelBridge.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ChannelBridge } from '../../src/managers/ChannelBridge';
+import type { ActiveModeManager } from '../../src/managers/ActiveModeManager';
+import type { ChannelEvent, ChannelInfo } from '../../src/providers/openclaw/OpenClawGateway';
+
+interface DelegateCall {
+  type: string;
+  panelId: string;
+  channelName?: string;
+  content?: string;
+  sender?: string;
+}
+
+function createBridgeHarness() {
+  let eventHandler: ((event: ChannelEvent) => void) | null = null;
+  const delegateCalls: DelegateCall[] = [];
+  const sent: Array<{ channelId?: string; message?: string; target?: string; prompt?: string; sessionKey?: string }> = [];
+
+  const channels: ChannelInfo[] = [
+    { id: 'wa-1', type: 'whatsapp', name: 'WhatsApp', status: 'connected' },
+    { id: 'tg-1', type: 'telegram', name: 'Telegram', status: 'connected' },
+  ];
+
+  const activeModeManager = {
+    isConnected: () => false,
+    isIntegrationEnabled: () => true,
+    getChannels: () => channels,
+    getSkills: () => [],
+    sendToChannel: vi.fn((channelId: string, message: string, target?: string) => {
+      sent.push({ channelId, message, target });
+      return Promise.resolve(true);
+    }),
+    sendAgentTask: vi.fn((prompt: string, sessionKey?: string) => {
+      sent.push({ prompt, sessionKey });
+      return Promise.resolve(true);
+    }),
+    subscribeToChannelEvents: vi.fn((handler: (event: ChannelEvent) => void) => {
+      eventHandler = handler;
+      return () => {
+        eventHandler = null;
+      };
+    }),
+  } as unknown as ActiveModeManager;
+
+  const bridge = new ChannelBridge(activeModeManager);
+  bridge.setDelegate({
+    hasPendingQuestion: () => false,
+    getPendingQuestionToolCallId: () => null,
+    answerPendingQuestion: (panelId: string, _toolCallId: string, content: string) => {
+      delegateCalls.push({ type: 'answerPendingQuestion', panelId, content });
+    },
+    cancelPanelRequest: (panelId: string) => {
+      delegateCalls.push({ type: 'cancelPanelRequest', panelId });
+    },
+    injectChannelMessage: (panelId: string, channelName: string, content: string, sender?: string) => {
+      delegateCalls.push({ type: 'injectChannelMessage', panelId, channelName, content, sender });
+    },
+    isRunning: () => false,
+    getActivePanelId: () => 'panel-1',
+  });
+
+  return {
+    bridge,
+    delegateCalls,
+    sent,
+    emit(event: ChannelEvent) {
+      if (!eventHandler) {
+        throw new Error('Channel event handler was not registered');
+      }
+      eventHandler(event);
+    },
+  };
+}
+
+describe('ChannelBridge channel-scoped contact tracking', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('rejects inbound messages from a tracked sender on a different channel', async () => {
+    const { bridge, delegateCalls, emit } = createBridgeHarness();
+
+    await bridge.executeSend({
+      type: 'send',
+      channel: 'whatsapp',
+      to: 'Bob',
+      content: 'hello',
+      startIndex: 0,
+    });
+
+    emit({
+      channelId: 'tg-1',
+      channelType: 'telegram',
+      eventType: 'message_received',
+      sender: 'Bob',
+      content: 'attacker-controlled reply',
+      timestamp: Date.now(),
+    });
+
+    expect(delegateCalls).toEqual([]);
+    bridge.dispose();
+  });
+
+  it('accepts inbound messages from a tracked sender on the same concrete channel', async () => {
+    const { bridge, delegateCalls, emit } = createBridgeHarness();
+
+    await bridge.executeSend({
+      type: 'send',
+      channel: 'whatsapp',
+      to: 'Bob',
+      content: 'hello',
+      startIndex: 0,
+    });
+
+    emit({
+      channelId: 'wa-1',
+      channelType: 'whatsapp',
+      eventType: 'message_received',
+      sender: 'Bob',
+      content: 'legitimate reply',
+      timestamp: Date.now(),
+    });
+
+    expect(delegateCalls).toEqual([
+      {
+        type: 'injectChannelMessage',
+        panelId: 'panel-1',
+        channelName: 'Whatsapp',
+        content: 'legitimate reply',
+        sender: 'Bob',
+      },
+    ]);
+    bridge.dispose();
+  });
+
+  it('accepts session-polling events that only expose the channel type fallback', async () => {
+    const { bridge, delegateCalls, emit } = createBridgeHarness();
+
+    await bridge.executeSend({
+      type: 'send',
+      channel: 'whatsapp',
+      to: 'Bob',
+      content: 'hello',
+      startIndex: 0,
+    });
+
+    emit({
+      channelId: 'whatsapp',
+      channelType: 'whatsapp',
+      eventType: 'message_received',
+      sender: 'Bob',
+      content: 'polling reply',
+      timestamp: Date.now(),
+    });
+
+    expect(delegateCalls).toHaveLength(1);
+    expect(delegateCalls[0]).toMatchObject({
+      type: 'injectChannelMessage',
+      channelName: 'Whatsapp',
+      content: 'polling reply',
+      sender: 'Bob',
+    });
+    bridge.dispose();
+  });
+});


### PR DESCRIPTION
# Fix channel-scoped OpenClaw contact tracking

Closes #42

## Summary

- Bind tracked OpenClaw contacts to channel-scoped identities instead of sender text alone.
- Require concrete inbound channel IDs to match the outbound channel ID, with a channel-type fallback for session polling events that do not expose a concrete channel ID.
- Tighten pending ask matching so replies from a different concrete channel do not satisfy an ask from another channel.
- Add ChannelBridge tests covering cross-channel rejection, same-channel acceptance, and session-polling fallback behavior.

## Testing

- `node node_modules/typescript/bin/tsc --noEmit --pretty false`
- `node node_modules/eslint/bin/eslint.js src/managers/ChannelBridge.ts tests/managers/channelBridge.test.ts --ext ts`
- Manual in-memory verification of the actual `ChannelBridge` class:
  - cross-channel `sender: "Bob"` rejected after WhatsApp tracking
  - same-channel `sender: "Bob"` accepted
  - pending ask cross-channel reply rejected

## Notes

- `node node_modules/vitest/vitest.mjs run tests/managers/channelBridge.test.ts` could not run in this environment because the installed Vite/Vitest versions require Node 20+, while this host has Node 18.19.1. TypeScript compilation and ESLint pass, and the actual class behavior was verified with a direct Node harness.
