### PR TITLE
Fix project memory key isolation

### DIFF
--- a/src/managers/MemoryManager.ts
+++ b/src/managers/MemoryManager.ts
@@ -32,6 +32,7 @@ import {
 const GLOBAL_STATE_KEY = 'mysti.autonomousMemory';
 const MEMORY_DIR_NAME = 'memory';
 const PROJECT_MEMORY_MAX_LINES = 200;
+const PROJECT_MEMORY_KEY_SCHEMA = 'mysti-project-memory-v2';
 
 interface MemoryStore {
   entries: MemoryEntry[];
@@ -282,7 +283,7 @@ export class MemoryManager {
    * Creates ~/.mysti/projects/<hash>/memory/ directory and loads MEMORY.md.
    */
   initProjectMemory(workspacePath: string): void {
-    const hash = crypto.createHash('sha256').update(workspacePath).digest('hex').substring(0, 12);
+    const hash = this._getProjectMemoryHash(workspacePath);
     const homeDir = process.env.HOME || process.env.USERPROFILE || '';
     this._projectMemoryDir = path.join(homeDir, '.mysti', 'projects', hash, 'memory');
 
@@ -408,6 +409,23 @@ export class MemoryManager {
     }
 
     this.writeProjectMemory(content);
+  }
+
+  private _getProjectMemoryHash(workspacePath: string): string {
+    const canonicalWorkspacePath = this._getCanonicalWorkspacePath(workspacePath);
+    const payload = JSON.stringify({
+      schema: PROJECT_MEMORY_KEY_SCHEMA,
+      canonicalWorkspacePath,
+    });
+    return crypto.createHash('sha256').update(payload).digest('hex');
+  }
+
+  private _getCanonicalWorkspacePath(workspacePath: string): string {
+    try {
+      return fs.realpathSync.native(workspacePath);
+    } catch {
+      return path.resolve(workspacePath);
+    }
   }
 
   private _loadProjectMemory(): void {

--- a/tests/managers/memoryManager.test.ts
+++ b/tests/managers/memoryManager.test.ts
@@ -1,0 +1,72 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type * as vscode from 'vscode';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryManager } from '../../src/managers/MemoryManager';
+
+function createMockContext(): vscode.ExtensionContext {
+  const state = new Map<string, unknown>();
+  return {
+    globalState: {
+      get: vi.fn((key: string) => state.get(key)),
+      update: vi.fn((key: string, value: unknown) => {
+        state.set(key, value);
+        return Promise.resolve();
+      }),
+    },
+  } as unknown as vscode.ExtensionContext;
+}
+
+describe('MemoryManager project memory keys', () => {
+  let tempRoot: string;
+  let oldHome: string | undefined;
+  let oldUserProfile: string | undefined;
+
+  beforeEach(() => {
+    tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mysti-memory-test-'));
+    oldHome = process.env.HOME;
+    oldUserProfile = process.env.USERPROFILE;
+    process.env.HOME = path.join(tempRoot, 'home');
+    process.env.USERPROFILE = process.env.HOME;
+    fs.mkdirSync(process.env.HOME, { recursive: true });
+  });
+
+  afterEach(() => {
+    process.env.HOME = oldHome;
+    process.env.USERPROFILE = oldUserProfile;
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('does not reuse project memory when the same lexical path points to a different real workspace', () => {
+    const victimProject = path.join(tempRoot, 'srv', 'users', 'alice', 'repo');
+    const attackerProject = path.join(tempRoot, 'srv', 'users', 'bob', 'repo');
+    const workDir = path.join(tempRoot, 'work');
+    const sharedWorkspacePath = path.join(workDir, 'current');
+    const victimMemory = '# Mysti Project Memory\n\n- VICTIM_ONLY_MEMORY\n';
+
+    fs.mkdirSync(victimProject, { recursive: true });
+    fs.mkdirSync(attackerProject, { recursive: true });
+    fs.mkdirSync(workDir, { recursive: true });
+
+    fs.symlinkSync(victimProject, sharedWorkspacePath, 'dir');
+
+    const victimManager = new MemoryManager(createMockContext());
+    victimManager.initProjectMemory(sharedWorkspacePath);
+    victimManager.writeProjectMemory(victimMemory);
+    const victimMemoryPath = victimManager.getProjectMemoryPath();
+    expect(victimManager.getProjectMemoryContent()).toContain('VICTIM_ONLY_MEMORY');
+    victimManager.dispose();
+
+    fs.unlinkSync(sharedWorkspacePath);
+    fs.symlinkSync(attackerProject, sharedWorkspacePath, 'dir');
+
+    const attackerManager = new MemoryManager(createMockContext());
+    attackerManager.initProjectMemory(sharedWorkspacePath);
+    const attackerMemoryPath = attackerManager.getProjectMemoryPath();
+
+    expect(attackerMemoryPath).not.toBe(victimMemoryPath);
+    expect(attackerManager.getProjectMemoryContent()).not.toContain('VICTIM_ONLY_MEMORY');
+    attackerManager.dispose();
+  });
+});


### PR DESCRIPTION
## Summary
- derive project auto-memory keys from a versioned canonical workspace identity instead of the raw workspace path string
- use the full SHA-256 digest for the project memory namespace
- add a regression test for symlink/path-alias reuse across different real workspaces

Fixes #46

## Verification
- node node_modules/typescript/bin/tsc --noEmit
- node node_modules/eslint/bin/eslint.js src/managers/MemoryManager.ts tests/managers/memoryManager.test.ts
- manual end-to-end validation using the real MemoryManager source confirmed the same lexical symlink path now maps to different memory directories after retargeting

Note: npm run test could not be executed in this environment because the local Node version is 18.19.1 while the installed Vitest/Vite versions require Node 20+, and node_modules/.bin is absent.