### PR TITLE
fix: project memory key isolation + legacy dir migration (lands #47)

### DIFF
--- a/src/managers/MemoryManager.ts
+++ b/src/managers/MemoryManager.ts
@@ -32,6 +32,7 @@ import {
 const GLOBAL_STATE_KEY = 'mysti.autonomousMemory';
 const MEMORY_DIR_NAME = 'memory';
 const PROJECT_MEMORY_MAX_LINES = 200;
+const PROJECT_MEMORY_KEY_SCHEMA = 'mysti-project-memory-v2';
 
 interface MemoryStore {
   entries: MemoryEntry[];
@@ -282,7 +283,7 @@ export class MemoryManager {
    * Creates ~/.mysti/projects/<hash>/memory/ directory and loads MEMORY.md.
    */
   initProjectMemory(workspacePath: string): void {
-    const hash = crypto.createHash('sha256').update(workspacePath).digest('hex').substring(0, 12);
+    const hash = this._getProjectMemoryHash(workspacePath);
     const homeDir = process.env.HOME || process.env.USERPROFILE || '';
     this._projectMemoryDir = path.join(homeDir, '.mysti', 'projects', hash, 'memory');
 
@@ -408,6 +409,23 @@ export class MemoryManager {
     }
 
     this.writeProjectMemory(content);
+  }
+
+  private _getProjectMemoryHash(workspacePath: string): string {
+    const canonicalWorkspacePath = this._getCanonicalWorkspacePath(workspacePath);
+    const payload = JSON.stringify({
+      schema: PROJECT_MEMORY_KEY_SCHEMA,
+      canonicalWorkspacePath,
+    });
+    return crypto.createHash('sha256').update(payload).digest('hex');
+  }
+
+  private _getCanonicalWorkspacePath(workspacePath: string): string {
+    try {
+      return fs.realpathSync.native(workspacePath);
+    } catch {
+      return path.resolve(workspacePath);
+    }
   }
 
   private _loadProjectMemory(): void {

--- a/src/managers/MemoryManager.ts
+++ b/src/managers/MemoryManager.ts
@@ -285,7 +285,9 @@ export class MemoryManager {
   initProjectMemory(workspacePath: string): void {
     const hash = this._getProjectMemoryHash(workspacePath);
     const homeDir = process.env.HOME || process.env.USERPROFILE || '';
-    this._projectMemoryDir = path.join(homeDir, '.mysti', 'projects', hash, 'memory');
+    const projectsDir = path.join(homeDir, '.mysti', 'projects');
+    this._migrateLegacyProjectMemory(projectsDir, workspacePath, hash);
+    this._projectMemoryDir = path.join(projectsDir, hash, 'memory');
 
     try {
       fs.mkdirSync(this._projectMemoryDir, { recursive: true });
@@ -425,6 +427,25 @@ export class MemoryManager {
       return fs.realpathSync.native(workspacePath);
     } catch {
       return path.resolve(workspacePath);
+    }
+  }
+
+  /**
+   * One-time migration: before the v2 key schema, project dirs were keyed by
+   * sha256(<literal workspace path>).substring(0, 12). Rename such a dir to the
+   * new canonical hash so existing project memory is not orphaned.
+   */
+  private _migrateLegacyProjectMemory(projectsDir: string, workspacePath: string, newHash: string): void {
+    try {
+      const legacyHash = crypto.createHash('sha256').update(workspacePath).digest('hex').substring(0, 12);
+      if (legacyHash === newHash) { return; }
+      const legacyDir = path.join(projectsDir, legacyHash);
+      const newDir = path.join(projectsDir, newHash);
+      if (!fs.existsSync(legacyDir) || fs.existsSync(newDir)) { return; }
+      fs.renameSync(legacyDir, newDir);
+      console.log(`[Mysti] Migrated legacy project memory ${legacyHash} -> ${newHash.substring(0, 12)}…`);
+    } catch (error) {
+      console.warn('[Mysti] Legacy project memory migration failed:', error);
     }
   }
 

--- a/tests/managers/memoryManager.test.ts
+++ b/tests/managers/memoryManager.test.ts
@@ -1,0 +1,72 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type * as vscode from 'vscode';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryManager } from '../../src/managers/MemoryManager';
+
+function createMockContext(): vscode.ExtensionContext {
+  const state = new Map<string, unknown>();
+  return {
+    globalState: {
+      get: vi.fn((key: string) => state.get(key)),
+      update: vi.fn((key: string, value: unknown) => {
+        state.set(key, value);
+        return Promise.resolve();
+      }),
+    },
+  } as unknown as vscode.ExtensionContext;
+}
+
+describe('MemoryManager project memory keys', () => {
+  let tempRoot: string;
+  let oldHome: string | undefined;
+  let oldUserProfile: string | undefined;
+
+  beforeEach(() => {
+    tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'mysti-memory-test-'));
+    oldHome = process.env.HOME;
+    oldUserProfile = process.env.USERPROFILE;
+    process.env.HOME = path.join(tempRoot, 'home');
+    process.env.USERPROFILE = process.env.HOME;
+    fs.mkdirSync(process.env.HOME, { recursive: true });
+  });
+
+  afterEach(() => {
+    process.env.HOME = oldHome;
+    process.env.USERPROFILE = oldUserProfile;
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it('does not reuse project memory when the same lexical path points to a different real workspace', () => {
+    const victimProject = path.join(tempRoot, 'srv', 'users', 'alice', 'repo');
+    const attackerProject = path.join(tempRoot, 'srv', 'users', 'bob', 'repo');
+    const workDir = path.join(tempRoot, 'work');
+    const sharedWorkspacePath = path.join(workDir, 'current');
+    const victimMemory = '# Mysti Project Memory\n\n- VICTIM_ONLY_MEMORY\n';
+
+    fs.mkdirSync(victimProject, { recursive: true });
+    fs.mkdirSync(attackerProject, { recursive: true });
+    fs.mkdirSync(workDir, { recursive: true });
+
+    fs.symlinkSync(victimProject, sharedWorkspacePath, 'dir');
+
+    const victimManager = new MemoryManager(createMockContext());
+    victimManager.initProjectMemory(sharedWorkspacePath);
+    victimManager.writeProjectMemory(victimMemory);
+    const victimMemoryPath = victimManager.getProjectMemoryPath();
+    expect(victimManager.getProjectMemoryContent()).toContain('VICTIM_ONLY_MEMORY');
+    victimManager.dispose();
+
+    fs.unlinkSync(sharedWorkspacePath);
+    fs.symlinkSync(attackerProject, sharedWorkspacePath, 'dir');
+
+    const attackerManager = new MemoryManager(createMockContext());
+    attackerManager.initProjectMemory(sharedWorkspacePath);
+    const attackerMemoryPath = attackerManager.getProjectMemoryPath();
+
+    expect(attackerMemoryPath).not.toBe(victimMemoryPath);
+    expect(attackerManager.getProjectMemoryContent()).not.toContain('VICTIM_ONLY_MEMORY');
+    attackerManager.dispose();
+  });
+});

--- a/tests/managers/memoryManager.test.ts
+++ b/tests/managers/memoryManager.test.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -68,5 +69,24 @@ describe('MemoryManager project memory keys', () => {
     expect(attackerMemoryPath).not.toBe(victimMemoryPath);
     expect(attackerManager.getProjectMemoryContent()).not.toContain('VICTIM_ONLY_MEMORY');
     attackerManager.dispose();
+  });
+
+  it('migrates a legacy v1-keyed project memory dir to the v2 key', () => {
+    const project = path.join(tempRoot, 'projects', 'legacy-repo');
+    fs.mkdirSync(project, { recursive: true });
+
+    // Seed a legacy dir keyed by sha256(<literal path>).substring(0, 12)
+    const legacyHash = crypto.createHash('sha256').update(project).digest('hex').substring(0, 12);
+    const legacyMemoryDir = path.join(process.env.HOME as string, '.mysti', 'projects', legacyHash, 'memory');
+    fs.mkdirSync(legacyMemoryDir, { recursive: true });
+    fs.writeFileSync(path.join(legacyMemoryDir, 'MEMORY.md'), '# Mysti Project Memory\n\n- LEGACY_MEMORY_CONTENT\n');
+
+    const manager = new MemoryManager(createMockContext());
+    manager.initProjectMemory(project);
+
+    expect(manager.getProjectMemoryContent()).toContain('LEGACY_MEMORY_CONTENT');
+    expect(manager.getProjectMemoryPath()).not.toContain(legacyHash);
+    expect(fs.existsSync(path.join(process.env.HOME as string, '.mysti', 'projects', legacyHash))).toBe(false);
+    manager.dispose();
   });
 });


### PR DESCRIPTION
Lands #47 by @3em0 (project memory keyed by canonicalized real path + schema-versioned full-length hash, fixing lexical-path reuse across different real workspaces) plus the missing piece: a one-time migration that renames legacy `~/.mysti/projects/<sha256(literal path)[0:12]>` dirs to the new canonical key, so existing users' project memory is not silently orphaned on upgrade.

Verified locally on Node 22: `tsc --noEmit` clean, memoryManager tests pass (symlink isolation + migration), full suite run below.

Closes #47. Fixes #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)