### PR TITLE
fix: restore broken star history chart

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -584,8 +584,8 @@ qwen  # ثم اكتب /auth
 </p>
 
 <p align="center">
-  <a href="https://star-history.com/#DeepMyst/Mysti&Date">
-    <img src="https://api.star-history.com/svg?repos=DeepMyst/Mysti&type=Date" width="600" alt="مخطط سجل النجوم" />
+  <a href="https://star-history.dera.page/#DeepMyst/Mysti&Date">
+    <img src="https://star-history.dera.page/svg?repos=DeepMyst/Mysti&type=Date" width="600" alt="مخطط سجل النجوم" />
   </a>
 </p>
 

--- a/README.de.md
+++ b/README.de.md
@@ -582,8 +582,8 @@ Wenn Mysti dir nützlich war, erwäge einen Star zu geben — es hilft anderen, 
 </p>
 
 <p align="center">
-  <a href="https://star-history.com/#DeepMyst/Mysti&Date">
-    <img src="https://api.star-history.com/svg?repos=DeepMyst/Mysti&type=Date" width="600" alt="Star-Verlaufsdiagramm" />
+  <a href="https://star-history.dera.page/#DeepMyst/Mysti&Date">
+    <img src="https://star-history.dera.page/svg?repos=DeepMyst/Mysti&type=Date" width="600" alt="Star-Verlaufsdiagramm" />
   </a>
 </p>
 

--- a/README.es.md
+++ b/README.es.md
@@ -582,8 +582,8 @@ Si Mysti te ha sido útil, considera darle una estrella — ¡ayuda a otros a de
 </p>
 
 <p align="center">
-  <a href="https://star-history.com/#DeepMyst/Mysti&Date">
-    <img src="https://api.star-history.com/svg?repos=DeepMyst/Mysti&type=Date" width="600" alt="Gráfico de Historial de Stars" />
+  <a href="https://star-history.dera.page/#DeepMyst/Mysti&Date">
+    <img src="https://star-history.dera.page/svg?repos=DeepMyst/Mysti&type=Date" width="600" alt="Gráfico de Historial de Stars" />
   </a>
 </p>
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -582,8 +582,8 @@ Si Mysti vous a été utile, pensez à lui donner une étoile — cela aide les 
 </p>
 
 <p align="center">
-  <a href="https://star-history.com/#DeepMyst/Mysti&Date">
-    <img src="https://api.star-history.com/svg?repos=DeepMyst/Mysti&type=Date" width="600" alt="Graphique de l'Historique des Stars" />
+  <a href="https://star-history.dera.page/#DeepMyst/Mysti&Date">
+    <img src="https://star-history.dera.page/svg?repos=DeepMyst/Mysti&type=Date" width="600" alt="Graphique de l'Historique des Stars" />
   </a>
 </p>
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -582,8 +582,8 @@ Mystiがお役に立ちましたら、ぜひStarをお願いします — プロ
 </p>
 
 <p align="center">
-  <a href="https://star-history.com/#DeepMyst/Mysti&Date">
-    <img src="https://api.star-history.com/svg?repos=DeepMyst/Mysti&type=Date" width="600" alt="Star履歴チャート" />
+  <a href="https://star-history.dera.page/#DeepMyst/Mysti&Date">
+    <img src="https://star-history.dera.page/svg?repos=DeepMyst/Mysti&type=Date" width="600" alt="Star履歴チャート" />
   </a>
 </p>
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -582,8 +582,8 @@ Mysti가 도움이 되셨다면 Star를 눌러주세요 — 다른 분들이 프
 </p>
 
 <p align="center">
-  <a href="https://star-history.com/#DeepMyst/Mysti&Date">
-    <img src="https://api.star-history.com/svg?repos=DeepMyst/Mysti&type=Date" width="600" alt="Star 히스토리 차트" />
+  <a href="https://star-history.dera.page/#DeepMyst/Mysti&Date">
+    <img src="https://star-history.dera.page/svg?repos=DeepMyst/Mysti&type=Date" width="600" alt="Star 히스토리 차트" />
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -591,8 +591,8 @@ If Mysti has been useful to you, consider giving it a star — it helps others d
 </p>
 
 <p align="center">
-  <a href="https://star-history.com/#DeepMyst/Mysti&Date">
-    <img src="https://api.star-history.com/svg?repos=DeepMyst/Mysti&type=Date" width="600" alt="Star History Chart" />
+  <a href="https://star-history.dera.page/#DeepMyst/Mysti&Date">
+    <img src="https://star-history.dera.page/svg?repos=DeepMyst/Mysti&type=Date" width="600" alt="Star History Chart" />
   </a>
 </p>
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -582,8 +582,8 @@ Se o Mysti foi útil para você, considere dar uma estrela — ajuda outros a de
 </p>
 
 <p align="center">
-  <a href="https://star-history.com/#DeepMyst/Mysti&Date">
-    <img src="https://api.star-history.com/svg?repos=DeepMyst/Mysti&type=Date" width="600" alt="Gráfico de Histórico de Stars" />
+  <a href="https://star-history.dera.page/#DeepMyst/Mysti&Date">
+    <img src="https://star-history.dera.page/svg?repos=DeepMyst/Mysti&type=Date" width="600" alt="Gráfico de Histórico de Stars" />
   </a>
 </p>
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -582,8 +582,8 @@ Mysti собирает **анонимные** данные об использо
 </p>
 
 <p align="center">
-  <a href="https://star-history.com/#DeepMyst/Mysti&Date">
-    <img src="https://api.star-history.com/svg?repos=DeepMyst/Mysti&type=Date" width="600" alt="График истории звёзд" />
+  <a href="https://star-history.dera.page/#DeepMyst/Mysti&Date">
+    <img src="https://star-history.dera.page/svg?repos=DeepMyst/Mysti&type=Date" width="600" alt="График истории звёзд" />
   </a>
 </p>
 

--- a/README.tr.md
+++ b/README.tr.md
@@ -582,8 +582,8 @@ Mysti işinize yaradıysa, bir star vermeyi düşünün — başkalarının proj
 </p>
 
 <p align="center">
-  <a href="https://star-history.com/#DeepMyst/Mysti&Date">
-    <img src="https://api.star-history.com/svg?repos=DeepMyst/Mysti&type=Date" width="600" alt="Star Geçmişi Grafiği" />
+  <a href="https://star-history.dera.page/#DeepMyst/Mysti&Date">
+    <img src="https://star-history.dera.page/svg?repos=DeepMyst/Mysti&type=Date" width="600" alt="Star Geçmişi Grafiği" />
   </a>
 </p>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -582,8 +582,8 @@ Mysti 收集**匿名**使用数据以改进扩展：
 </p>
 
 <p align="center">
-  <a href="https://star-history.com/#DeepMyst/Mysti&Date">
-    <img src="https://api.star-history.com/svg?repos=DeepMyst/Mysti&type=Date" width="600" alt="Star 历史图表" />
+  <a href="https://star-history.dera.page/#DeepMyst/Mysti&Date">
+    <img src="https://star-history.dera.page/svg?repos=DeepMyst/Mysti&type=Date" width="600" alt="Star 历史图表" />
   </a>
 </p>
 


### PR DESCRIPTION
The star history chart on the README is currently broken: the old service can no longer render it due to GitHub stargazer API restrictions, so the chart shows nothing.

This PR points the chart to the star-history.dera.page mirror, which uses a different data source that requires no API token and serves both the frontend and the SVG endpoint from the same domain. The same fix is applied to every localized README.